### PR TITLE
Improve repository name

### DIFF
--- a/repository.yaml
+++ b/repository.yaml
@@ -1,4 +1,4 @@
 ---
-name: Add-On Repository for Cloudflare
+name: Cloudflared
 url: https://github.com/brenner-tobias/ha-addons
 maintainer: Tobia Brenner <https://github.com/brenner-tobias/>


### PR DESCRIPTION
This section heading doesn't look great, especially since it says `Cloudflare` instead of `Cloudflared` which is potentially confusing.

![Screenshot 2022-10-12 at 15 55 42](https://user-images.githubusercontent.com/247634/195377584-fdd47d06-603e-46b6-a568-91b8c2a40a43.png)

How about just `Cloudflared`, which matches the (official) `ESPHome` section heading in my screenshot.

So it would look like this:

![image](https://user-images.githubusercontent.com/247634/195378119-5e828617-ff4f-4e08-9300-99c7210c69e1.png)